### PR TITLE
Compatibility and bugsfixes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Setuptools >58.0.0 removed the build_py_2to3 function that is used in pycrypto's setup.py.
+pip install Setuptools==58.0.0
 # TMP solution until new versions of sflock etc are released to PyPI
 pip install -U git+https://github.com/cert-ee/sflock
 pip install -U git+https://github.com/cert-ee/roach

--- a/machineries/cuckoo/machineries/modules/qemu.py
+++ b/machineries/cuckoo/machineries/modules/qemu.py
@@ -544,10 +544,10 @@ class QEMU(Machinery):
         path = Path(vm.disposables_dir, f"{vm.machine.name}_disposable.qcow2")
         command = [
             self.cfg["binaries"]["qemu_img"],
-            "create", "-f", "qcow2",
+            "create", "-F", "qcow2",
             "-o", "lazy_refcounts=on,cluster_size=2M",
             "-b", vm.qcow2_path,
-            str(path)
+            "-f", "qcow2", str(path)
         ]
         try:
             subprocess.run(

--- a/processing/cuckoo/processing/signatures/pattern.py
+++ b/processing/cuckoo/processing/signatures/pattern.py
@@ -1022,6 +1022,9 @@ class PatternScanner:
         if not scandb:
             return
 
+        if not isinstance(scan_str, bytes):
+            scan_str = scan_str.encode("utf-8")
+
         scandb.scan(
             scan_str, self._on_match,
             context=(scan_str, orig_str, event, event_kind, processing_ctx,


### PR DESCRIPTION
I had the following problems using cuckoo:

- cuckoo uses pycrypto which can only be used if an older setuptools version is used. Therefore I added a pip install line on the install script to ensure the right version is used
- I got an error from qemu-image because options where given in an outdated manner for my version, so I updated the options. (They still work with the qemu version used in ubuntu20.04)
- I got the same error described in #18, so I introduce a check to scan_str to make sure it's a bytes object and if not it castes it to a bytes object

I tested it on manjaro and ubunto20.04 with python3.8 and it worked just fine