### PR TITLE
Added Proxmox support as it is really popular

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -41,3 +41,6 @@ nav:
     - Endpoints: usage/webapi/endpoints.md
   - Web UI: usage/webui/setup.md
   - Commands: usage/commands.md
+
+- Development:
+  - Creating new machinery modules: development/creating_machinery.md

--- a/docs/src/development/creating_machinery.md
+++ b/docs/src/development/creating_machinery.md
@@ -178,3 +178,42 @@ powered of machine)
     For examples check the modules `QEMU` and `kvm`
     in `$A/machineries/cuckoo/machineries/abstracts`
 
+### Optional machinery functions
+
+```python
+def norestore_start(self, machine):
+    raise NotImplementedError
+```
+
+As the name suggest, this function starts the VM like `restore_start`.
+But unlike `restore_start` the given snapshot isn't restored.
+
+```python
+def acpi_stop(self, machine):
+    raise NotImplementedError
+```
+
+The same as the `stop` function but shutdowns the machine
+gracefully instead of virtually pulling the plug.
+
+```python
+def dump_memory(self, machine, path):
+    raise NotImplementedError
+```
+
+Does exactly what the name suggest. This may not be possible with all
+machineries. Prominently the `kvm` module does not support this function.
+
+```python
+def handle_paused(self, machine):
+    raise NotImplementedError
+```
+
+Some machineries may restore the VM to a paused state, like the `QEMU`
+machinery. This function is used to unpaused the machine.
+
+!!! note "Note"
+    It is also a good idea to override existing machinery functions
+    if you need to alter their functionality. (e.g. `load_machines`
+    gets overwritten by the `kvm` module)
+

--- a/docs/src/development/creating_machinery.md
+++ b/docs/src/development/creating_machinery.md
@@ -1,0 +1,180 @@
+## Machinery modules
+
+This page describes how to create new module
+for not yet supported machineries.
+Notably, Key steps that aren't apparent
+or require extended reversing of the code base are discussed here.
+
+This page can also be used to extend an existing module.
+
+### How to create a machinery module
+
+**1. Creating a basic Template**
+
+To accomplish this step, first create a file like:
+`$A/machineries/cuckoo/machineries/modules/<module_name>.py`.
+In the python file, create a class which represents the machinery
+you wish to implement.
+The class must inherit the abstract class `Machinery`.
+
+Additionally, the `machines` module, `cfg` function and `errors` module
+must be imported, to get access to machines and configuration data
+as well as machinery specific exceptions.
+Importing `CuckooGlobalLogger` will also come in handy for logging behaviour.
+
+Finally the basic class should look like this:
+
+```python
+from cuckoo.common import machines
+from cuckoo.common.config import cfg
+from cuckoo.common.log import CuckooGlobalLogger
+
+from .. import errors
+from ..abstracts import Machinery
+
+log = CuckooGlobalLogger(__name__)
+
+class Machinery_Name(Machinery):
+    pass
+
+```
+!!! note "Note"
+    The class won't be loaded by Cuckoo yet
+    and will be make loadable at a later point of this Tutorial.
+
+**2. Define configuration constrains**
+!!! warning "Warning"
+    This Step can't be skipped or an exception will occur while
+    Cuckoo tries to load the configuration file corresponding to the module.
+
+To enable Cuckoo to load the corresponding configuration file
+of the new machinery module, an entry must be created in the `typeloaders`
+Variable of the `cuckoo.machineries.config` module.
+The `cuckoo.machineries.config` module is found in
+`$A/machineries/cuckoo/machineries/config.py`.
+
+It is a good idea to copy an existing entry and modify it
+for ones own module.
+
+An example can be seen here:
+```python
+...
+typeloaders = {
+    "qemu.yaml": {
+        "interface": config.NetworkInterface(
+            default_val="br0", must_exist=True, must_be_up=False
+        ),
+        "disposable_copy_dir": config.DirectoryPath(
+            allow_empty=True, must_exist=True, writable=True
+        ),
+        "binaries": {
+            "qemu_img": config.FilePath(
+                "/usr/bin/qemu-img", readable=True, executable=True
+            ),
+            "qemu_system_x86_64": config.FilePath(
+                default_val="/usr/bin/qemu-system-x86_64", readable=True,
+                executable=True
+            )
+        },
+        "machines": config.NestedDictionary("example1", {
+                "qcow2_path": config.FilePath(default_val="/home/cuckoo/.vmcloak/vms/qemu/win10_1/disk.qcow2", readable=True),
+                "snapshot_path": config.FilePath(default_val="/home/cuckoo/.vmcloak/vms/qemu/win10_1/memory.snapshot", readable=True),
+                "machineinfo_path": config.FilePath("/home/cuckoo/.vmcloak/vms/qemu/win10_1/machineinfo.json", readable=True),
+                "ip": config.String(default_val="192.168.30.101"),
+                "mac_address": MACAddress(to_lower=True, allow_empty=True,
+                                          required=False),
+                "platform": config.String(
+                    default_val="windows", to_lower=True
+                ),
+                "os_version": config.String(default_val="10"),
+                "architecture": config.String(
+                    default_val="amd64", to_lower=True
+                ),
+                "interface": config.NetworkInterface(
+                    allow_empty=True, must_exist=True, must_be_up=False,
+                    required=False
+                ),
+                "agent_port": config.Int(
+                    default_val=8000, required=False, min_value=1,
+                    max_value=2**16-1
+                ),
+                "tags": config.List(
+                    config.String, ["exampletag1", "exampletag2"],
+                    allow_empty=True
+                )
+        })
+    }
+}
+...
+```
+
+**3. Making the module loadable**
+
+To make the module loadable, one has to create a variable
+called `name` in the machinery class
+and initialize it with the name of the module.
+Now the module looks like this:
+
+```python
+from cuckoo.common import machines
+from cuckoo.common.config import cfg
+from cuckoo.common.log import CuckooGlobalLogger
+
+from .. import errors
+from ..abstracts import Machinery
+
+log = CuckooGlobalLogger(__name__)
+
+class Machinery_Name(Machinery):
+    name = "Machinery_Name"
+
+```
+
+**4. Populating the Module with the minimum functions to work**
+
+The `Machinery` class suggest that the seven functions `restore_start`,
+`norestore_start`, `stop`, `acpi_stop`, `state`, `dump_memory`
+and `handle_paused` must be implemented for a machinery module to work.
+This is not the case as can be seen in the given modules `QEMU`
+and `kvm`.
+
+The minimum functions to be implemented are: `restore_start`, `stop`
+and `state`. This functions will be discuss in the following:
+
+```python
+def restore_start(self, machine):
+    raise NotImplementedError
+```
+
+The `restore_start` function is called to revert to a VMs snapshot
+and is used for the standard analysis routine.
+
+In this function the status of the machine must be checked
+and if the machine is turned off, the machine can be safely restored.
+
+```python
+def stop(self, machine):
+    raise NotImplementedError
+```
+
+The `stop` function is called when the analysis concluded.
+The VM will then be shut downed in an ungraceful manner.
+This is equal to pulling the cord on your computer.
+As the VM will be restored for the next analysis this isn't a problem.
+Also a check must take place to figure out if the VM is running,
+before stopping it.
+
+```python
+def state(self, machine):
+    raise NotImplementedError
+```
+
+The `state` function is used to get a Cuckoo compatible state
+of a given VM. This function is heavily used to ensure that
+no invalid action are applied to VM. (e.g. Turning off a already
+powered of machine)
+
+!!! note "Note"
+    For examples check the modules `QEMU` and `kvm`
+    in `$A/machineries/cuckoo/machineries/abstracts`
+

--- a/docs/src/development/creating_machinery.md
+++ b/docs/src/development/creating_machinery.md
@@ -178,6 +178,19 @@ powered of machine)
     For examples check the modules `QEMU` and `kvm`
     in `$A/machineries/cuckoo/machineries/abstracts`
 
+### Config-Template
+
+After fisnishing the machinery-module, you will want to create a Config-Template.
+This will prevent `cuckoo createcwd` from producing an error and will create
+an example config from installation on.
+
+The Config-Template is a jinja2 document. It's name must chosen like this:
+`<module-name>.yaml.jinja2` and be located in `cuckoo3/machineries/cuckoo/machineries/data/conftemplates`
+The file must contain the configuration constrains defined earlier.
+
+!!! note "Note"
+    Using an existing Template is a great starting point for this step.
+
 ### Optional machinery functions
 
 ```python

--- a/machineries/cuckoo/machineries/config.py
+++ b/machineries/cuckoo/machineries/config.py
@@ -18,6 +18,38 @@ class MACAddress(config.String):
 
 exclude_autoload = []
 typeloaders = {
+    "proxmox.yaml": {
+        "dsn": config.String(default_val="xxx.xxx.xxx.xxx"),
+        "interface": config.NetworkInterface(
+            default_val="eno1", must_be_up=False
+        ),
+        "machines": config.NestedDictionary("example1", {
+                "label": config.String(default_val="example1"),
+                "ip": config.String(default_val="192.168.1.101"),
+                "platform": config.String(
+                    default_val="windows", to_lower=True
+                ),
+                "os_version": config.String(default_val="10"),
+                "mac_address": MACAddress(allow_empty=True, to_lower=True,
+                                          required=False),
+                "snapshot": config.String(allow_empty=True, required=False),
+                "interface": config.NetworkInterface(
+                    allow_empty=True, must_be_up=False, must_exist=False,
+                    required=False
+                ),
+                "agent_port": config.Int(
+                    default_val=8000, required=False, min_value=1,
+                    max_value=2**16-1
+                ),
+                "architecture": config.String(
+                    default_val="amd64", to_lower=True
+                ),
+                "tags": config.List(
+                    config.String, ["exampletag1", "exampletag2"],
+                    allow_empty=True
+                )
+        })
+    },
     "kvm.yaml": {
         "dsn": config.String(default_val="qemu:///system"),
         "interface": config.NetworkInterface(

--- a/machineries/cuckoo/machineries/config.py
+++ b/machineries/cuckoo/machineries/config.py
@@ -20,6 +20,8 @@ exclude_autoload = []
 typeloaders = {
     "proxmox.yaml": {
         "dsn": config.String(default_val="xxx.xxx.xxx.xxx"),
+        "user": config.String(default_val="root@pam"),
+        "pw": config.String(default_val="input your password here"),
         "interface": config.NetworkInterface(
             default_val="eno1", must_be_up=False
         ),

--- a/machineries/cuckoo/machineries/data/conftemplates/proxmox.yaml.jinja2
+++ b/machineries/cuckoo/machineries/data/conftemplates/proxmox.yaml.jinja2
@@ -1,0 +1,49 @@
+# Specify a IP-address for the proxmox server
+# This module uses the std-port 8006 and as of now cant be changed.
+dsn: "{{ dsn }}"
+
+# The User you want to use for connecting to proxmox
+user: "{{ user }}"
+
+# The corresponding password to the user
+pw: "{{ pw }}"
+
+# The Interface where the Analysis VMs also are
+interface: {{ interface}}
+
+machines:
+{% for name, machine in machines.items() %}
+  {{ name }}:
+    # The name of the Analysis VM specified in Proxmox
+    # as for now the proxmox vmid is not supported
+    label: {{ machine.label}}
+    # The static IP address that has been configured inside of the machine.
+    ip: {{ machine.ip }}
+    # The operating system platform installed on the machine.
+    platform: {{ machine.platform }}
+    # A string that specifies the version of the operating system installed.
+    # Example: "10" for Windows 10, "7" for Windows 7, "18.04" for Ubuntu 18.04.
+    os_version: "{{ machine.os_version }}"
+    # The system architecture. Amd64, ARM, etc. This is used to
+    # select the correct stager and monitor builds/component for the machine.
+    architecture: {{ machine.architecture }}
+    # The TCP port of the agent running on the machine.
+    agent_port: {{ machine.agent_port }}
+    # (Optional) The MAC address of the network interface of the machine that is used to connect to
+    # to the resultserver and the internet.
+    mac_address: {{ machine.mac_address }}
+    # (Optional) a named snapshot that Cuckoo must restore the machine to
+    # after each analysis. If this snapshot is not provided, a 'current' snapshot must be set.
+    snapshot: {{ machine.snapshot }}
+    # (Optional) Specify the name of the network interface that should be used
+    # when dumping network traffic from this machine with tcpdump.
+    interface: {{ machine.interface }}
+    # Machine tags that identify the installed software and other characteristics of the machine.
+    # These are used to select the correct machine for a sample that has dependencies. *Notice*: correct tags are
+    # crucial in selecting machines that can actually run a submitted sample.
+    # Existing automatic tags can be found in the conf/processing/identification.yaml config.
+    tags:
+    {% for tag in machine.tags %}
+    - {{ tag }}
+    {% endfor %}
+{% endfor %}

--- a/machineries/cuckoo/machineries/modules/proxmox.py
+++ b/machineries/cuckoo/machineries/modules/proxmox.py
@@ -45,6 +45,10 @@ class Proxmox(Machinery):
     def version(self):
         breakpoint()
 
+    def _create_proxmoxer_connection(self):
+        return ProxmoxAPI(self.dsn, user=self.user, password=self.pw,
+                          verify_ssl=False)
+
     @staticmethod
     def verify_dependencies():
         if not _HAVE_PROXMOXER:

--- a/machineries/cuckoo/machineries/modules/proxmox.py
+++ b/machineries/cuckoo/machineries/modules/proxmox.py
@@ -44,5 +44,10 @@ class Proxmox(Machinery):
 
     @staticmethod
     def verify_dependencies():
-        breakpoint()
+        if not _HAVE_PROXMOXER:
+            raise errors.MachineryDependencyError(
+                    "Python package 'proxmoxer' is not installed. "
+                    "To install it, the following python dependency must also be "
+                    "installed: 'pip install proxmoxer'"
+                    )
 

--- a/machineries/cuckoo/machineries/modules/proxmox.py
+++ b/machineries/cuckoo/machineries/modules/proxmox.py
@@ -1,0 +1,46 @@
+import threading
+
+from cuckoo.common import machines
+from cuckoo.common import cfg
+
+from .. import errors
+from ..abstracts import Machinery
+
+try:
+    import proxmoxer
+    _HAVE_PROXMOXER = True
+except ImportError:
+    _HAVE_PROXMOXER = False
+
+class Proxmox(Machinery):
+    def init(self):
+        pass
+
+    def restore_start(self, machine):
+        pass
+
+    def norestore_start(self, machine):
+        pass
+
+    def stop(self, machine):
+        pass
+
+    def acpi_stop(self, machine):
+        pass
+
+    def state(self, machine):
+        pass
+
+    def dump_memory(self, machine, path):
+        pass
+
+    def handle_paused(self, machine):
+        pass
+
+    def version(self):
+        pass
+
+    @staticmethod
+    def verify_dependencies():
+        pass
+

--- a/machineries/cuckoo/machineries/modules/proxmox.py
+++ b/machineries/cuckoo/machineries/modules/proxmox.py
@@ -13,6 +13,8 @@ except ImportError:
     _HAVE_PROXMOXER = False
 
 class Proxmox(Machinery):
+    name = "proxmox"
+
     def init(self):
         pass
 

--- a/machineries/cuckoo/machineries/modules/proxmox.py
+++ b/machineries/cuckoo/machineries/modules/proxmox.py
@@ -1,5 +1,7 @@
 import threading
 
+from dataclasses import dataclass
+
 from cuckoo.common import machines
 from cuckoo.common.config import cfg
 
@@ -20,6 +22,26 @@ class Proxmox(Machinery):
         self.user = cfg("proxmox.yaml", "user", subpkg="machineries")
         self.pw = cfg("proxmox.yaml", "pw", subpkg="machineries")
         self.vms = {}
+
+    def load_machines(self):
+        """Get all IDs needed to control the VMs and check config problems"""
+        super().load_machines()
+        for machine in self.list_machines():
+            vm_id, vm_node = self._get_vm_info(machine.label)
+            self.vms[machine.label] = _VM(vm_id, vm_node)
+            if machine.snapshot is None:
+                prox = self._create_proxmoxer_connection()
+                tmp = prox.nodes(vm_node).qemu(vm_id).snapshot.get()
+                if tmp is None:
+                    raise errors.MachineryConnectionError(
+                            f"A problem occurred while getting the snapshot of {machine.label}"
+                            )
+                # There is always an extra "you are here" element in the list
+                elif len(tmp) <= 1:
+                    raise errors.MachineNotFoundError(
+                            f"The Machine {machine.label} has no snapshots"
+                            )
+                machine.snapshot = tmp[0]["name"]
 
     def restore_start(self, machine):
         breakpoint()
@@ -49,6 +71,49 @@ class Proxmox(Machinery):
         return ProxmoxAPI(self.dsn, user=self.user, password=self.pw,
                           verify_ssl=False)
 
+    def _get_vm_info(self, name):
+        """
+        Get vm_id and node_name by iterating through all nodes and searching for the name.
+        Wont stop on first occurence, instead it will try to detect ambiguity
+        and if it does it will raise an exception.
+        """
+        prox = self._create_proxmoxer_connection()
+
+        vm_id = 0
+        vm_node = ""
+        nodes = prox.nodes.get()
+        if nodes is None:
+            raise errors.MachineryConnectionError(
+                    f"Cloudn't get Node list from Proxmox server."
+                    )
+        elif len(nodes) <= 1:
+            raise errors.MachineNotFoundError(
+                    f"No Nodes found while loading Machines Info"
+                    )
+        for node in nodes:
+            node_name = node["node"]
+            vm_list = prox.nodes(node_name).qemu.get()
+            if vm_list is None:
+                raise errors.MachineryConnectionError(
+                        f"Couldn't get VMs from Proxmox node {node_name}"
+                        )
+            for vm in vm_list:
+                vm_name = vm.get("name")
+                if vm_name == name:
+                    if vm_node != "":
+                        raise errors.MachineUnexpectedStateError(
+                                f"Two VMs have the same name {vm_name}"
+                                )
+                    vm_id = vm["vmid"]
+                    vm_node = node_name
+
+        if vm_id == 0:
+            raise errors.MachineNotFoundError(
+                    f"Cloudn't find a vm with {name} as name"
+                    )
+        else:
+            return vm_id, vm_node
+
     @staticmethod
     def verify_dependencies():
         if not _HAVE_PROXMOXER:
@@ -57,4 +122,14 @@ class Proxmox(Machinery):
                     "To install it, the following python dependency must also be "
                     "installed: 'pip install proxmoxer'"
                     )
+
+
+@dataclass
+class _VM:
+    vm_id: int
+    node_name: str
+
+    def __init__(self, vm_id, node_name):
+        self.vm_id = vm_id
+        self.node_name = node_name
 

--- a/machineries/cuckoo/machineries/modules/proxmox.py
+++ b/machineries/cuckoo/machineries/modules/proxmox.py
@@ -16,7 +16,10 @@ class Proxmox(Machinery):
     name = "proxmox"
 
     def init(self):
-        breakpoint()
+        self.dsn = cfg("proxmox.yaml", "dsn", subpkg="machineries")
+        self.user = cfg("proxmox.yaml", "user", subpkg="machineries")
+        self.pw = cfg("proxmox.yaml", "pw", subpkg="machineries")
+        self.vms = {}
 
     def restore_start(self, machine):
         breakpoint()

--- a/machineries/cuckoo/machineries/modules/proxmox.py
+++ b/machineries/cuckoo/machineries/modules/proxmox.py
@@ -68,8 +68,13 @@ class Proxmox(Machinery):
         breakpoint()
 
     def _create_proxmoxer_connection(self):
-        return ProxmoxAPI(self.dsn, user=self.user, password=self.pw,
+        tmp = ProxmoxAPI(self.dsn, user=self.user, password=self.pw,
                           verify_ssl=False)
+        if tmp is None:
+            raise errors.MachineryConnectionError(
+                    f"Couldn't connect to Proxmox."
+                    )
+        return tmp
 
     def _get_vm_info(self, name):
         """

--- a/machineries/cuckoo/machineries/modules/proxmox.py
+++ b/machineries/cuckoo/machineries/modules/proxmox.py
@@ -1,5 +1,3 @@
-import threading
-
 from dataclasses import dataclass
 
 from cuckoo.common import machines
@@ -78,7 +76,7 @@ class Proxmox(Machinery):
         log.info(f"restore_start from {machine.label} completed.")
 
     def norestore_start(self, machine):
-        breakpoint()
+        raise NotImplemented
 
     def stop(self, machine):
         state = self.state(machine)
@@ -102,7 +100,7 @@ class Proxmox(Machinery):
         log.info(f"{machine.label} was stopped")
 
     def acpi_stop(self, machine):
-        breakpoint()
+        raise NotImplemented
 
     def state(self, machine):
         vm = self.vms.get(machine.label)
@@ -136,13 +134,13 @@ class Proxmox(Machinery):
         return state
 
     def dump_memory(self, machine, path):
-        breakpoint()
+        raise NotImplemented
 
     def handle_paused(self, machine):
-        breakpoint()
+        raise NotImplemented
 
     def version(self):
-        breakpoint()
+        raise NotImplemented
 
     def _create_proxmoxer_connection(self):
         tmp = ProxmoxAPI(self.dsn, user=self.user, password=self.pw,

--- a/machineries/cuckoo/machineries/modules/proxmox.py
+++ b/machineries/cuckoo/machineries/modules/proxmox.py
@@ -16,33 +16,33 @@ class Proxmox(Machinery):
     name = "proxmox"
 
     def init(self):
-        pass
+        breakpoint()
 
     def restore_start(self, machine):
-        pass
+        breakpoint()
 
     def norestore_start(self, machine):
-        pass
+        breakpoint()
 
     def stop(self, machine):
-        pass
+        breakpoint()
 
     def acpi_stop(self, machine):
-        pass
+        breakpoint()
 
     def state(self, machine):
-        pass
+        breakpoint()
 
     def dump_memory(self, machine, path):
-        pass
+        breakpoint()
 
     def handle_paused(self, machine):
-        pass
+        breakpoint()
 
     def version(self):
-        pass
+        breakpoint()
 
     @staticmethod
     def verify_dependencies():
-        pass
+        breakpoint()
 

--- a/machineries/cuckoo/machineries/modules/proxmox.py
+++ b/machineries/cuckoo/machineries/modules/proxmox.py
@@ -7,7 +7,7 @@ from .. import errors
 from ..abstracts import Machinery
 
 try:
-    import proxmoxer
+    from proxmoxer import ProxmoxAPI
     _HAVE_PROXMOXER = True
 except ImportError:
     _HAVE_PROXMOXER = False

--- a/machineries/cuckoo/machineries/modules/proxmox.py
+++ b/machineries/cuckoo/machineries/modules/proxmox.py
@@ -91,7 +91,7 @@ class Proxmox(Machinery):
             raise errors.MachineryConnectionError(
                     f"Cloudn't get Node list from Proxmox server."
                     )
-        elif len(nodes) <= 1:
+        elif len(nodes) <= 0:
             raise errors.MachineNotFoundError(
                     f"No Nodes found while loading Machines Info"
                     )

--- a/machineries/cuckoo/machineries/modules/proxmox.py
+++ b/machineries/cuckoo/machineries/modules/proxmox.py
@@ -1,7 +1,7 @@
 import threading
 
 from cuckoo.common import machines
-from cuckoo.common import cfg
+from cuckoo.common.config import cfg
 
 from .. import errors
 from ..abstracts import Machinery


### PR DESCRIPTION
Proxmox is one of the most popular tools for hosting VMs and containers, so I implemented a Proxmox machinery module.
This feature was also requested in issue #3 .

I also created a development section in the docs, where I generally explained how a machinery module is created.

I had to reverse parts of the Code to figure out how to create a machinery module, therefore the docs may not be 100% accurate.