### PR TITLE
Proxmox unstable connection

### DIFF
--- a/machineries/cuckoo/machineries/config.py
+++ b/machineries/cuckoo/machineries/config.py
@@ -22,6 +22,7 @@ typeloaders = {
         "dsn": config.String(default_val="xxx.xxx.xxx.xxx"),
         "user": config.String(default_val="root@pam"),
         "pw": config.String(default_val="input your password here"),
+        "timeout": config.Int(default_val=10),
         "interface": config.NetworkInterface(
             default_val="eno1", must_be_up=False
         ),

--- a/machineries/cuckoo/machineries/data/conftemplates/proxmox.yaml.jinja2
+++ b/machineries/cuckoo/machineries/data/conftemplates/proxmox.yaml.jinja2
@@ -8,6 +8,9 @@ user: "{{ user }}"
 # The corresponding password to the user
 pw: "{{ pw }}"
 
+# Timeout for establishing a connection
+timeout: {{ timeout }}
+
 # The Interface where the Analysis VMs also are
 interface: {{ interface}}
 

--- a/machineries/cuckoo/machineries/modules/proxmox.py
+++ b/machineries/cuckoo/machineries/modules/proxmox.py
@@ -168,21 +168,8 @@ class Proxmox(Machinery):
         is needed.
         """
         log.debug(f"Attempting to connect to Proxmox server in {self.dsn}")
-
-        for count in range(3):
-            try:
-                tmp = ProxmoxAPI(self.dsn, user=self.user, password=self.pw,
+        tmp = ProxmoxAPI(self.dsn, user=self.user, password=self.pw,
                           verify_ssl=False)
-            except (TimeoutError):
-                log.warning("Connection to Proxmox timedout retrying...")
-                if count >= 2:
-                    log.error("Aborting on timedout")
-                    raise errors.MachineryConnectionError(
-                            f"Connection to proxmox timedout 3 times."
-                            )
-                else:
-                    pass
-
         if tmp is None:
             raise errors.MachineryConnectionError(
                     f"Couldn't connect to Proxmox."

--- a/machineries/cuckoo/machineries/modules/proxmox.py
+++ b/machineries/cuckoo/machineries/modules/proxmox.py
@@ -168,8 +168,21 @@ class Proxmox(Machinery):
         is needed.
         """
         log.debug(f"Attempting to connect to Proxmox server in {self.dsn}")
-        tmp = ProxmoxAPI(self.dsn, user=self.user, password=self.pw,
+
+        for count in range(3):
+            try:
+                tmp = ProxmoxAPI(self.dsn, user=self.user, password=self.pw,
                           verify_ssl=False)
+            except (TimeoutError):
+                log.warning("Connection to Proxmox timedout retrying...")
+                if count >= 2:
+                    log.error("Aborting on timedout")
+                    raise errors.MachineryConnectionError(
+                            f"Connection to proxmox timedout 3 times."
+                            )
+                else:
+                    pass
+
         if tmp is None:
             raise errors.MachineryConnectionError(
                     f"Couldn't connect to Proxmox."

--- a/machineries/cuckoo/machineries/modules/proxmox.py
+++ b/machineries/cuckoo/machineries/modules/proxmox.py
@@ -22,6 +22,7 @@ class Proxmox(Machinery):
         self.dsn = cfg("proxmox.yaml", "dsn", subpkg="machineries")
         self.user = cfg("proxmox.yaml", "user", subpkg="machineries")
         self.pw = cfg("proxmox.yaml", "pw", subpkg="machineries")
+        self.timeout = cfg("proxmox.yaml", "timeout", subpkg="machineries")
         self.vms = {}
 
     def load_machines(self):
@@ -168,8 +169,14 @@ class Proxmox(Machinery):
         is needed.
         """
         log.debug(f"Attempting to connect to Proxmox server in {self.dsn}")
-        tmp = ProxmoxAPI(self.dsn, user=self.user, password=self.pw,
-                          verify_ssl=False)
+        try:
+            tmp = ProxmoxAPI(self.dsn, user=self.user, password=self.pw,
+                          verify_ssl=False, timeout=self.timeout)
+        except Exception as e:
+            log.error(f"Connecting to Proxmox server timedout"
+                      f"Try increasing the timeout value in <cwd>)/conf/machineries/proxmox.yaml")
+            raise e
+
         if tmp is None:
             raise errors.MachineryConnectionError(
                     f"Couldn't connect to Proxmox."


### PR DESCRIPTION
the default time out of proxmoxers ProxmoxAPI-function is pretty short and im getting errors because of this.
I fix it by adding a timeout param in the proxmox.yaml file.