### PR TITLE
Python 3.10 fix: Remove loop argument

### DIFF
--- a/node/cuckoo/node/resultserver.py
+++ b/node/cuckoo/node/resultserver.py
@@ -440,7 +440,7 @@ class _AsyncResultServer:
         incoming results that are mapped."""
         self.loop = asyncio.get_event_loop()
         routine = asyncio.start_server(
-            self.new_result, listen_ip, listen_port, loop=self.loop
+            self.new_result, listen_ip, listen_port
         )
 
         try:


### PR DESCRIPTION
The loop argument to asyncio.create_server had been deprecated in Python 3.8 and was removed in Python 3.10. See https://docs.python.org/3/whatsnew/3.10.html#changes-python-api for details.