### PR TITLE
machinery-based screenshots

### DIFF
--- a/common/setup.py
+++ b/common/setup.py
@@ -48,6 +48,7 @@ setuptools.setup(
         "aiohttp>=3.8.1, <3.9",
         "aiohttp-sse-client>=0.2.1, <0.3",
         "psutil>=5.9.0, <5.10",
-        "alembic[tz]"
+        "alembic[tz]",
+        "Pillow"
     ]
 )

--- a/core/cuckoo/data/conftemplates/cuckoo.yaml.jinja2
+++ b/core/cuckoo/data/conftemplates/cuckoo.yaml.jinja2
@@ -12,6 +12,10 @@ machineries:
   - {{ machinery }}
 {% endfor %}
 
+# Enable screenshots of analysis machines while running.
+machinery_screenshots:
+  enabled: {{ machinery_screenshots.enabled }}
+
 # The resultserver is a Cuckoo component that running analysis machines upload their results to
 # it should be reachable from the analysis machine. A resultserver will be started on the configured
 # listen IP and port. Make sure the IP is off a network interface that is part of the analysis machine network or

--- a/docs/src/configuration/cuckooconfs/cuckooyaml.md
+++ b/docs/src/configuration/cuckooconfs/cuckooyaml.md
@@ -19,6 +19,10 @@ the chosen machinery module(s).
 machineries:
   - kvm
 
+# Enable screenshots of analysis machines while running.
+machinery_screenshots:
+  enabled: False
+
 # The resultserver is a Cuckoo component that running analysis machines upload their results to
 # it should be reachable from the analysis machine. A resultserver will be started on the configured
 # listen IP and port. Make sure the IP is off a network interface that is part of the analysis machine network or

--- a/machineries/cuckoo/machineries/abstracts.py
+++ b/machineries/cuckoo/machineries/abstracts.py
@@ -85,6 +85,9 @@ class Machinery:
     def handle_paused(self, machine):
         raise NotImplementedError
 
+    def screenshot(self, machine, path):
+        raise NotImplementedError
+
     def start_netcapture(self, machine, pcap_path, ignore_ip_ports=[]):
         if machine.interface:
             capture_interface = machine.interface

--- a/node/cuckoo/node/machinery.py
+++ b/node/cuckoo/node/machinery.py
@@ -145,6 +145,11 @@ def dump_memory(machine):
         expected_state=machines.States.RUNNING, state_timeout=60
     )
 
+def screenshot(machine):
+    if not cfg("cuckoo.yaml", "machinery_screenshots", "enabled"):
+        return
+    # TODO use timestamp-based screenshots similar to cuckoo 3's resultserver
+
 def machine_state(machine):
     """Return a normalized machine state of the given machine."""
     return machine.machinery.state(machine)
@@ -577,7 +582,8 @@ class MachineryManager(UnixSocketServer):
         "restore_start": restore_start,
         "norestore_start": norestore_start,
         "stop": stop,
-        "acpi_stop": acpi_stop
+        "acpi_stop": acpi_stop,
+        "screenshot": screenshot,
     }
 
     # TODO read number of MachineryWorkers from a configuration file?


### PR DESCRIPTION
This starts porting machinery-based screenshot capabilities added to CAPE in https://github.com/kevoreilly/CAPEv2/pull/1814 to Cuckoo 3.