### PR TITLE
Fixes to ElasticSearch's startup and VirusTotal reporting

### DIFF
--- a/common/cuckoo/common/elastic.py
+++ b/common/cuckoo/common/elastic.py
@@ -95,10 +95,29 @@ class _ESManager:
         self._initialized = True
 
     def verify(self):
-        if not self.client.ping():
+        log.debug("Connecting to Elasticsearch.")
+        if self.client.ping():
+            verified = True
+            failures = 0
+        else:
+            verified = False
+            failures = 1
+
+        while not verified and failures < 6:
+            time.sleep(10)
+            if not self.client.ping():
+                failures += 1
+            else:
+                verified = True
+
+        if not verified:
             raise ElasticSearchError(
                 "Could not connect to Elasticsearch host(s)"
             )
+        elif failures > 0:
+           log.warn(f"Connected to Elasticsearch host after {failures} attempts.")
+        else:
+            log.debug("Connected to Elasticsearch host.")
 
     def all_indices_exist(self):
         self.verify()

--- a/common/cuckoo/common/elastic.py
+++ b/common/cuckoo/common/elastic.py
@@ -90,8 +90,12 @@ class _ESManager:
 
         self._max_result_window = max_result_window
         self._hosts = hosts
-        self._client = Elasticsearch(hosts, timeout=timeout,
-                                     http_auth=(user, password), ca_certs=ca_certs)
+        if ca_certs:
+            self._client = Elasticsearch(hosts, timeout=timeout,
+                                         http_auth=(user, password), ca_certs=ca_certs)
+        else:
+            self._client = Elasticsearch(hosts, timeout=timeout,
+                                         http_auth=(user, password))
         self._initialized = True
 
     def verify(self):
@@ -153,7 +157,7 @@ class _ESManager:
         existing = []
         for name, realname in self._names_realnames.items():
             try:
-                if self.client.indices.exists(realname):
+                if self.client.indices.exists(index=realname):
                     existing.append(name)
             except (ApiError, TransportError) as e:
                 raise ElasticSearchError(

--- a/common/cuckoo/common/strictcontainer.py
+++ b/common/cuckoo/common/strictcontainer.py
@@ -8,6 +8,7 @@ import dateutil.parser
 
 from .storage import safe_json_dump, split_analysis_id
 from .log import CuckooGlobalLogger
+from vt.object import WhistleBlowerDict
 
 log = CuckooGlobalLogger(__name__)
 
@@ -32,6 +33,9 @@ def serialize_disk_json(obj):
 
     if isinstance(obj, StrictContainer):
         return obj.to_dict()
+
+    if isinstance(obj, WhistleBlowerDict):
+        return dict(obj)
 
     log.warning(
         "Unhandled object type in JSON disk serialization", object=repr(obj),

--- a/core/cuckoo/startup.py
+++ b/core/cuckoo/startup.py
@@ -374,10 +374,16 @@ def _init_elasticsearch_pre_startup():
     ca_certs = config.cfg(
         "elasticsearch.yaml", "ca_certs", subpkg="processing"
     )
-    init_elasticsearch(
-        hosts, indices, timeout=timeout, max_result_window=max_result,
-        create_missing_indices=True, user=user, password=password, ca_certs=ca_certs
-    )
+    if "https://" in hosts[0]:
+        init_elasticsearch(
+            hosts, indices, timeout=timeout, max_result_window=max_result,
+            create_missing_indices=True, user=user, password=password, ca_certs=ca_certs
+        )
+    else:
+        init_elasticsearch(
+            hosts, indices, timeout=timeout, max_result_window=max_result,
+            create_missing_indices=True, user=user, password=password
+        )
 
 
 def start_cuckoo(loglevel, cancel_abandoned=False):

--- a/processing/cuckoo/processing/reporting/elastic.py
+++ b/processing/cuckoo/processing/reporting/elastic.py
@@ -41,11 +41,18 @@ class ElasticSearch(Reporter):
         ca_certs = cfg(
             "elasticsearch.yaml",  "ca_certs", subpkg="processing"
         )
-        init_elasticsearch(
-            hosts, indices, timeout=timeout, max_result_window=max_result,
-            create_missing_indices=False,
-            user=user, password=password, ca_certs=ca_certs
-        )
+        if "https://" in hosts[0]:
+            init_elasticsearch(
+                hosts, indices, timeout=timeout, max_result_window=max_result,
+                create_missing_indices=False,
+                user=user, password=password, ca_certs=ca_certs
+            )
+        else:
+            init_elasticsearch(
+                hosts, indices, timeout=timeout, max_result_window=max_result,
+                create_missing_indices=False,
+                user=user, password=password
+            )
 
     def report_pre_analysis(self):
         try:

--- a/web/cuckoo/web/web/startup.py
+++ b/web/cuckoo/web/web/startup.py
@@ -47,15 +47,25 @@ def _init_elasticsearch_web():
     password = cfg("web.yaml", "elasticsearch", "password", subpkg="web")
     ca_certs = cfg("web.yaml", "elasticsearch", "ca_certs", subpkg="web")
 
-    init_elasticsearch(
-        hosts,
-        indices,
-        max_result_window=max_window,
-        create_missing_indices=False,
-        user=user,
-        password=password,
-        ca_certs=ca_certs,
-    )
+    if "https://" in hosts[0]:
+        init_elasticsearch(
+            hosts,
+            indices,
+            max_result_window=max_window,
+            create_missing_indices=False,
+            user=user,
+            password=password,
+            ca_certs=ca_certs,
+        )
+    else:
+        init_elasticsearch(
+            hosts,
+            indices,
+            max_result_window=max_window,
+            create_missing_indices=False,
+            user=user,
+            password=password,
+        )
 
 
 def _init_statistics_web():


### PR DESCRIPTION
# Description

This PR fixes 3 issues I have encountered. They are:

* Cuckoo not starting due to ElasticSearch being running, but not actually up yet.
* Failures to startup Cuckoo when the local ElasticSearch is not using TLS.
* The reporting module for VirusTotal failing to display results in the web.

For the first two, my changes delay Cuckoo3's startup by up to 60 seconds to give time for ElasticSearch to be fully functional and check if the first ElasticSearch endpoint in the config is using HTTPS as a transport, respectively.

For the latter, the `vt` library that is used to query VirusTotal changed the returned results class wrapper, so I added an additional check before serialising the returned object to disk.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tried unsuccessfully to start Cuckoo3 a bunch of times after pulling the latest updates.
- [x] Debugged the errors and made live-changes in prod until it started.
- [x] Debugged the errors in the reporting causing it to go HTTP 500 and confirmed, by disabling the module, that this was caused by problems with jinja parsing VirusTotal results on disk.
- [x] Changed the `serialize_disk_json()` function from `strictcontainer.py` to take into account the new return class (`WhistleBlowerDict`) of the object, re-enabled the VT processor module and tested a bunch of files (known-good and known-bad) in Cuckoo to see if it would fail again.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have docstrings in all functions, classes and methods
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have made only one pull request for this issue
- [ ] I have separated testing and production environments
