### PR TITLE
Make common module available for pyright

### DIFF
--- a/common/cuckoo/__init__.py
+++ b/common/cuckoo/__init__.py
@@ -1,0 +1,2 @@
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)
+


### PR DESCRIPTION

# Description

Current project structure does not enable pyright to identify common package as a module and gives unresolved import warnings. This is a temporary fix and will be replaced by structure overhaul in the future

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation change

# How Has This Been Tested?

- Locally by making changes and reinstalling cuckoo to see if `cuckoo` command still runs without problems


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have docstrings in all functions, classes and methods
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have made only one pull request for this issue
