### PR TITLE
remove deprecated utcnow method

### DIFF
--- a/common/cuckoo/common/db.py
+++ b/common/cuckoo/common/db.py
@@ -3,7 +3,7 @@
 
 import sqlalchemy
 
-from datetime import datetime
+from datetime import datetime, timezone
 from sqlalchemy.ext.declarative import as_declarative
 from sqlalchemy.orm import sessionmaker, relationship
 from sqlalchemy.pool import NullPool
@@ -47,7 +47,7 @@ class Analysis(CuckooDBTable):
     id = sqlalchemy.Column(sqlalchemy.String(15), primary_key=True)
     kind = sqlalchemy.Column(sqlalchemy.String(32), nullable=False)
     created_on = sqlalchemy.Column(
-        sqlalchemy.DateTime, nullable=False, default=datetime.utcnow()
+        sqlalchemy.DateTime, nullable=False, default=datetime.now(timezone.utc)
     )
     state = sqlalchemy.Column(sqlalchemy.String(32), nullable=False)
     priority = sqlalchemy.Column(sqlalchemy.Integer, default=1, nullable=False)

--- a/common/cuckoo/common/intelmq.py
+++ b/common/cuckoo/common/intelmq.py
@@ -3,7 +3,7 @@
 
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from urllib.parse import urljoin
 import elasticsearch_dsl
 import requests
@@ -88,7 +88,7 @@ class IntelMQEventMaker:
     def _add_event(self, event_dict, taxonomy, classification_type):
         event_dict.update(
             {
-                Fields.TIME_SOURCE: datetime.utcnow().isoformat(),
+                Fields.TIME_SOURCE: datetime.now(timezone.utc).isoformat(),
                 Fields.TAXONOMY: taxonomy,
                 Fields.TYPE: classification_type,
             }

--- a/common/cuckoo/common/machines.py
+++ b/common/cuckoo/common/machines.py
@@ -3,7 +3,7 @@
 
 import json
 import threading
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from .log import CuckooGlobalLogger
 from .storage import safe_json_dump
@@ -443,7 +443,7 @@ class MachineListDumper:
         if not self._last_dump:
             return True
 
-        if datetime.utcnow() - self._last_dump >= timedelta(
+        if datetime.now(timezone.utc) - self._last_dump >= timedelta(
             seconds=self._min_dump_wait
         ):
             return True
@@ -455,7 +455,7 @@ class MachineListDumper:
 
     def make_dump(self, path):
         dump_machine_lists(path, *self.lists)
-        self._last_dump = datetime.utcnow()
+        self._last_dump = datetime.now(timezone.utc)
 
         self._lists_changed = False
         for mlist in self.lists:

--- a/common/cuckoo/common/node.py
+++ b/common/cuckoo/common/node.py
@@ -2,7 +2,7 @@
 # See the file 'LICENSE' for copying permission.
 
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from cuckoo.common.machines import read_machines_dump_dict
 from cuckoo.common.route import Routes
@@ -125,7 +125,7 @@ class NodeInfos:
         if not self._last_dump:
             return True
 
-        if datetime.utcnow() - self._last_dump >= timedelta(
+        if datetime.now(timezone.utc) - self._last_dump >= timedelta(
             seconds=self._min_dump_wait
         ):
             return True
@@ -137,7 +137,7 @@ class NodeInfos:
 
     def make_dump(self, path):
         dump_nodeinfos(path, *self.nodeinfos)
-        self._last_dump = datetime.utcnow()
+        self._last_dump = datetime.now(timezone.utc)
 
         self._changed = False
         for info in self.nodeinfos:

--- a/common/cuckoo/common/storage.py
+++ b/common/cuckoo/common/storage.py
@@ -8,7 +8,7 @@ import random
 import shutil
 import string
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import gettempdir
 
@@ -744,7 +744,7 @@ def create_analysis_folder(day, identifier):
 
 
 def todays_daydir():
-    return datetime.utcnow().date().strftime("%Y%m%d")
+    return datetime.now(timezone.utc).date().strftime("%Y%m%d")
 
 
 def make_analysis_folder(tries=0):

--- a/common/cuckoo/common/submit.py
+++ b/common/cuckoo/common/submit.py
@@ -5,7 +5,7 @@ import json
 import os.path
 import shlex
 from copy import deepcopy
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from threading import RLock
 
@@ -73,7 +73,7 @@ def _write_analysis(analysis_id, settings, target_strictcontainer):
             "kind": AnalysisKinds.STANDARD,
             "state": AnalysisStates.UNTRACKED,
             "settings": settings,
-            "created_on": datetime.utcnow(),
+            "created_on": datetime.now(timezone.utc),
             "category": target_strictcontainer.category,
             "submitted": target_strictcontainer,
         }
@@ -587,7 +587,7 @@ class SettingsMaker:
 
         # Check if the dump file changed if the last reload is at least
         # RELOAD MINS minutes ago
-        if datetime.utcnow() - self._last_reload < timedelta(minutes=self.RELOAD_MINS):
+        if datetime.now(timezone.utc) - self._last_reload < timedelta(minutes=self.RELOAD_MINS):
             return False
 
         # Only reload if the dump file was actually modified since last check
@@ -627,7 +627,7 @@ class SettingsMaker:
 
         with self._dmp_load_lock:
             self._last_modify_time = self._dump_modify_dt()
-            self._last_reload = datetime.utcnow()
+            self._last_reload = datetime.now(timezone.utc)
             self.nodeinfos = read_nodesinfos_dump(self._nodeinfos_dump_path)
 
     def available_platforms(self):

--- a/core/cuckoo/control.py
+++ b/core/cuckoo/control.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2019-2021 Estonian Information System Authority.
 # See the file 'LICENSE' for copying permission.
 
-from datetime import datetime
+from datetime import datetime, timezone
 import os
 import queue
 import threading
@@ -236,7 +236,7 @@ def handle_post_done(worktracker):
         worktracker.task.id,
         score=post.score,
         state=worktracker.task.state,
-        stopped_on=datetime.utcnow(),
+        stopped_on=datetime.now(timezone.utc),
     )
 
     # Update analysis score, tags, and detected families
@@ -295,7 +295,7 @@ def set_failed(worktracker, worktype):
         worktracker.analysis.update_task(
             worktracker.task.id,
             state=worktracker.task.state,
-            stopped_on=datetime.utcnow(),
+            stopped_on=datetime.now(timezone.utc),
         )
         task.write_changes(worktracker.task)
         update_final_analysis_state(worktracker)
@@ -323,7 +323,7 @@ def set_task_failed(worktracker):
     task.merge_run_errors(worktracker.task)
     worktracker.task.state = task.States.FATAL_ERROR
     worktracker.analysis.update_task(
-        worktracker.task.id, state=worktracker.task.state, stopped_on=datetime.utcnow()
+        worktracker.task.id, state=worktracker.task.state, stopped_on=datetime.now(timezone.utc)
     )
     analyses.write_changes(worktracker.analysis)
     task.write_changes(worktracker.task)
@@ -340,7 +340,7 @@ def set_task_running(worktracker, machine, node):
         state=worktracker.task.state,
         platform=machine.platform,
         os_version=machine.os_version,
-        started_on=datetime.utcnow(),
+        started_on=datetime.now(timezone.utc),
     )
     task.write_changes(worktracker.task)
     analyses.write_changes(worktracker.analysis)


### PR DESCRIPTION
# Description

All deprecated datetime.utcnow was replaced to datetime.now(timezone.utc)

Fixes #226 

## Type of change

- [x] Refactoring (non-breaking changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation change

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Made changes locally and run analysis
- [x] Analysis completed successfully

# Checklist:
If some of these checklist item do not apply (for example small refactoring changes), then check the indented box below the checklist item

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] Does not apply
- [ ] I have docstrings in all functions, classes and methods
  - [ ] Does not apply
- [ ] I have made corresponding changes to the documentation
  - [ ] Does not apply
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Does not apply
- [ ] New and existing unit tests pass locally with my changes (can be skipped for now)
- [ ] Any dependent changes have been merged and published in downstream modules
  - [ ] Does not apply
- [ ] I have made only one pull request for this issue
